### PR TITLE
Feature: ajout des wallets

### DIFF
--- a/apps/api/prisma/migrations/20240618084431_create_wallet_table/migration.sql
+++ b/apps/api/prisma/migrations/20240618084431_create_wallet_table/migration.sql
@@ -1,0 +1,18 @@
+-- CreateEnum
+CREATE TYPE "Currencies" AS ENUM ('USD', 'EUR', 'GBP', 'JPY', 'RUB');
+
+-- CreateTable
+CREATE TABLE "wallet" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "currency" "Currencies" NOT NULL,
+    "current_balance" DOUBLE PRECISION NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "user_id" TEXT NOT NULL,
+
+    CONSTRAINT "wallet_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "wallet" ADD CONSTRAINT "wallet_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20240618085241_create_wallet_table/migration.sql
+++ b/apps/api/prisma/migrations/20240618085241_create_wallet_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "wallet" ALTER COLUMN "current_balance" SET DEFAULT 0;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -7,6 +7,14 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Currencies {
+  USD
+  EUR
+  GBP
+  JPY
+  RUB
+}
+
 model User {
   id       String  @id @default(cuid())
   email    String  @unique
@@ -16,5 +24,22 @@ model User {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
+  wallets Wallet[]
+
   @@map("user")
+}
+
+model Wallet {
+  id             String     @id @default(cuid())
+  name           String
+  currency       Currencies
+  currentBalance Float      @default(0) @map("current_balance")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String @map("user_id")
+
+  @@map("wallet")
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { AppAuthGuard } from './auth/guards/app-auth.guard'
 import { CommonModule } from './common/common.module'
 import config from './common/config/config'
 import { UsersModule } from './users/users.module'
+import { WalletsModule } from './wallets/wallets.module'
 
 import type { ApolloDriverConfig } from '@nestjs/apollo'
 import type { HttpException } from '@nestjs/common'
@@ -29,6 +30,7 @@ import type { HttpException } from '@nestjs/common'
       autoSchemaFile: 'src/graphql/schema.gql',
       sortSchema: true,
       introspection: true,
+      fieldResolverEnhancers: ['guards'],
       formatError: err => {
         const originalError = err.extensions?.originalError as
           | HttpException
@@ -49,7 +51,8 @@ import type { HttpException } from '@nestjs/common'
     }),
     CommonModule,
     UsersModule,
-    AuthModule
+    AuthModule,
+    WalletsModule
   ],
   providers: [
     {

--- a/apps/api/src/common/decorators/parent-args.decorator.ts
+++ b/apps/api/src/common/decorators/parent-args.decorator.ts
@@ -1,0 +1,23 @@
+import { createParamDecorator } from '@nestjs/common'
+import { GqlExecutionContext } from '@nestjs/graphql'
+import { plainToInstance } from 'class-transformer'
+
+import type { ExecutionContext } from '@nestjs/common'
+import type { ClassConstructor } from 'class-transformer'
+
+interface ContextInfo {
+  variableValues: unknown
+}
+
+export const ParentArgs = createParamDecorator(
+  (cls: ClassConstructor<unknown> | undefined, context: ExecutionContext) => {
+    const ctx = GqlExecutionContext.create(context)
+    const info = ctx.getInfo<ContextInfo>()
+
+    if (cls) {
+      return plainToInstance(cls, info.variableValues)
+    }
+
+    return info.variableValues
+  }
+)

--- a/apps/api/src/common/dto/currencies.dto.ts
+++ b/apps/api/src/common/dto/currencies.dto.ts
@@ -1,0 +1,42 @@
+import { Field, InputType, registerEnumType } from '@nestjs/graphql'
+
+export enum Currencies {
+  USD = 'USD',
+  EUR = 'EUR',
+  GBP = 'GBP',
+  JPY = 'JPY',
+  RUB = 'RUB'
+}
+
+registerEnumType(Currencies, {
+  name: 'Currencies',
+  description:
+    'The available currencies that can be used within the application.'
+})
+
+@InputType()
+export class EnumCurrenciesFilter {
+  @Field(() => Currencies, {
+    nullable: true,
+    description: 'Checks for equality with the specified value.'
+  })
+  equals?: keyof typeof Currencies;
+
+  @Field(() => [Currencies], {
+    nullable: true,
+    description: 'Checks for equality with the specified values.'
+  })
+  in?: (keyof typeof Currencies)[]
+
+  @Field(() => [Currencies], {
+    nullable: true,
+    description: 'Checks for inequality with the specified values.'
+  })
+  notIn?: (keyof typeof Currencies)[]
+
+  @Field(() => EnumCurrenciesFilter, {
+    nullable: true,
+    description: 'Negates the specified condition.'
+  })
+  not?: EnumCurrenciesFilter
+}

--- a/apps/api/src/common/dto/prisma.dto.ts
+++ b/apps/api/src/common/dto/prisma.dto.ts
@@ -1,0 +1,347 @@
+/* eslint-disable @typescript-eslint/naming-convention -- If we want to use Prisma's naming convention for Enums, we need to disable this rule */
+import { Field, Float, InputType, Int, registerEnumType } from '@nestjs/graphql'
+
+export enum SortOrder {
+  asc = 'asc',
+  desc = 'desc'
+}
+
+registerEnumType(SortOrder, {
+  name: 'SortOrder',
+  description:
+    'Specifies the order of sorting: ascending (asc) or descending (desc).'
+})
+
+export enum NullsOrder {
+  first = 'first',
+  last = 'last'
+}
+
+registerEnumType(NullsOrder, {
+  name: 'NullsOrder',
+  description:
+    'Defines how null values should be handled during sorting: first (nulls first) or last (nulls last).'
+})
+
+export enum QueryMode {
+  default = 'default',
+  insensitive = 'insensitive'
+}
+
+registerEnumType(QueryMode, {
+  name: 'QueryMode',
+  description:
+    'Defines the mode for filtering strings, either default or case-insensitive.'
+})
+
+@InputType({
+  description:
+    'Defines the criteria for sorting results based on string values.'
+})
+export class SortOrderInput {
+  @Field(() => SortOrder, {
+    description:
+      'Specifies the order of sorting: ascending (asc) or descending (desc).'
+  })
+  sort: keyof typeof SortOrder
+
+  @Field(() => NullsOrder, {
+    nullable: true,
+    description:
+      'Defines how null values should be handled during sorting: first (nulls first) or last (nulls last).'
+  })
+  nulls?: keyof typeof NullsOrder
+}
+
+@InputType({
+  description:
+    'Defines the criteria for filtering results based on string values.'
+})
+export class StringFilter {
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Filters results to only include those that match this exact string.'
+  })
+  equals?: string;
+
+  @Field(() => [String], {
+    nullable: true,
+    description:
+      'Filters results to only include those that match any of the specified strings.'
+  })
+  in?: string[]
+
+  @Field(() => [String], {
+    nullable: true,
+    description:
+      'Filters results to exclude those that match any of the specified strings.'
+  })
+  notIn?: string[]
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are less than the specified string.'
+  })
+  lt?: string
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are less than or equal to the specified string.'
+  })
+  lte?: string
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are greater than the specified string.'
+  })
+  gt?: string
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are greater than or equal to the specified string.'
+  })
+  gte?: string
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Filters results to include those that contain the specified substring.'
+  })
+  contains?: string
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Filters results to include those that start with the specified string.'
+  })
+  startsWith?: string
+
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'Filters results to include those that end with the specified string.'
+  })
+  endsWith?: string
+
+  @Field(() => QueryMode, {
+    nullable: true,
+    description:
+      'Defines the mode for filtering strings, either default or case-insensitive.'
+  })
+  mode?: keyof typeof QueryMode
+
+  @Field(() => StringFilter, {
+    nullable: true,
+    description:
+      'Allows for nested string filtering, applying additional filter criteria.'
+  })
+  not?: StringFilter
+}
+
+@InputType({
+  description:
+    'Defines the criteria for filtering results based on integer values.'
+})
+export class IntFilter {
+  @Field(() => Int, {
+    nullable: true,
+    description:
+      'Filters results to only include those that match this exact integer.'
+  })
+  equals?: number;
+
+  @Field(() => [Int], {
+    nullable: true,
+    description:
+      'Filters results to only include those that match any of the specified integers.'
+  })
+  in?: number[]
+
+  @Field(() => [Int], {
+    nullable: true,
+    description:
+      'Filters results to exclude those that match any of the specified integers.'
+  })
+  notIn?: number[]
+
+  @Field(() => Int, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are less than the specified integer.'
+  })
+  lt?: number
+
+  @Field(() => Int, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are less than or equal to the specified integer.'
+  })
+  lte?: number
+
+  @Field(() => Int, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are greater than the specified integer.'
+  })
+  gt?: number
+
+  @Field(() => Int, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are greater than or equal to the specified integer.'
+  })
+  gte?: number
+
+  @Field(() => IntFilter, {
+    nullable: true,
+    description:
+      'Allows for nested integer filtering, applying additional filter criteria.'
+  })
+  not?: IntFilter
+}
+
+@InputType({
+  description:
+    'Defines the criteria for filtering results based on floating-point values.'
+})
+export class DateTimeFilter {
+  @Field(() => Date, {
+    nullable: true,
+    description:
+      'Filters results to only include those that match this exact date or date string.'
+  })
+  equals?: Date | string;
+
+  @Field(() => [Date], {
+    nullable: true,
+    description:
+      'Filters results to only include those that match any of the specified dates or date strings.'
+  })
+  in?: Date[] | string[]
+
+  @Field(() => [Date], {
+    nullable: true,
+    description:
+      'Filters results to exclude those that match any of the specified dates or date strings.'
+  })
+  notIn?: Date[] | string[]
+
+  @Field(() => Date, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are earlier than the specified date or date string.'
+  })
+  lt?: Date | string
+
+  @Field(() => Date, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are earlier than or equal to the specified date or date string.'
+  })
+  lte?: Date | string
+
+  @Field(() => Date, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are later than the specified date or date string.'
+  })
+  gt?: Date | string
+
+  @Field(() => Date, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are later than or equal to the specified date or date string.'
+  })
+  gte?: Date | string
+
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+    description:
+      'Allows for nested date filtering, applying additional filter criteria.'
+  })
+  not?: DateTimeFilter
+}
+
+@InputType({
+  description:
+    'Defines the criteria for filtering results based on boolean values.'
+})
+export class BoolFilter {
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'Filters results to only include those that match this exact boolean value.'
+  })
+  equals?: boolean
+
+  @Field(() => BoolFilter, {
+    nullable: true,
+    description:
+      'Allows for nested boolean filtering, applying additional filter criteria.'
+  })
+  not?: BoolFilter
+}
+
+@InputType()
+export class FloatFilter {
+  @Field(() => Float, {
+    nullable: true,
+    description:
+      'Filters results to only include those that match this exact float.'
+  })
+  equals?: number;
+
+  @Field(() => [Float], {
+    nullable: true,
+    description:
+      'Filters results to only include those that match any of the specified floats.'
+  })
+  in?: number[]
+
+  @Field(() => [Float], {
+    nullable: true,
+    description:
+      'Filters results to exclude those that match any of the specified floats.'
+  })
+  notIn?: number[]
+
+  @Field(() => Float, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are less than the specified float.'
+  })
+  lt?: number
+
+  @Field(() => Float, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are less than or equal to the specified float.'
+  })
+  lte?: number
+
+  @Field(() => Float, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are greater than the specified float.'
+  })
+  gt?: number
+
+  @Field(() => Float, {
+    nullable: true,
+    description:
+      'Filters results to only include those that are greater than or equal to the specified float.'
+  })
+  gte?: number
+
+  @Field(() => FloatFilter, {
+    nullable: true,
+    description:
+      'Allows for nested float filtering, applying additional filter criteria.'
+  })
+  not?: FloatFilter
+}

--- a/apps/api/src/graphql/schema.gql
+++ b/apps/api/src/graphql/schema.gql
@@ -21,14 +21,136 @@ input CreateUserInput {
 }
 
 """
+Defines the data required to create a new wallet within the application.
+"""
+input CreateWalletInput {
+  """The currency that the wallet will use."""
+  currency: Currencies!
+
+  """The balance of the wallet. Defaults to 0."""
+  currentBalance: Float
+
+  """
+  The name of the wallet. This field must be unique within the wallet table.
+  """
+  name: String!
+}
+
+"""
 A field whose value conforms to the standard cuid format as specified in https://github.com/ericelliott/cuid#broken-down
 """
 scalar Cuid @specifiedBy(url: "https://github.com/ericelliott/cuid#broken-down")
+
+"""The available currencies that can be used within the application."""
+enum Currencies {
+  EUR
+  GBP
+  JPY
+  RUB
+  USD
+}
 
 """
 A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
 """
 scalar DateTime
+
+"""
+Defines the criteria for filtering results based on floating-point values.
+"""
+input DateTimeFilter {
+  """
+  Filters results to only include those that match this exact date or date string.
+  """
+  equals: DateTime
+
+  """
+  Filters results to only include those that are later than the specified date or date string.
+  """
+  gt: DateTime
+
+  """
+  Filters results to only include those that are later than or equal to the specified date or date string.
+  """
+  gte: DateTime
+
+  """
+  Filters results to only include those that match any of the specified dates or date strings.
+  """
+  in: [DateTime!]
+
+  """
+  Filters results to only include those that are earlier than the specified date or date string.
+  """
+  lt: DateTime
+
+  """
+  Filters results to only include those that are earlier than or equal to the specified date or date string.
+  """
+  lte: DateTime
+
+  """Allows for nested date filtering, applying additional filter criteria."""
+  not: DateTimeFilter
+
+  """
+  Filters results to exclude those that match any of the specified dates or date strings.
+  """
+  notIn: [DateTime!]
+}
+
+input EnumCurrenciesFilter {
+  """Checks for equality with the specified value."""
+  equals: Currencies
+
+  """Checks for equality with the specified values."""
+  in: [Currencies!]
+
+  """Negates the specified condition."""
+  not: EnumCurrenciesFilter
+
+  """Checks for inequality with the specified values."""
+  notIn: [Currencies!]
+}
+
+input FloatFilter {
+  """Filters results to only include those that match this exact float."""
+  equals: Float
+
+  """
+  Filters results to only include those that are greater than the specified float.
+  """
+  gt: Float
+
+  """
+  Filters results to only include those that are greater than or equal to the specified float.
+  """
+  gte: Float
+
+  """
+  Filters results to only include those that match any of the specified floats.
+  """
+  in: [Float!]
+
+  """
+  Filters results to only include those that are less than the specified float.
+  """
+  lt: Float
+
+  """
+  Filters results to only include those that are less than or equal to the specified float.
+  """
+  lte: Float
+
+  """
+  Allows for nested float filtering, applying additional filter criteria.
+  """
+  not: FloatFilter
+
+  """
+  Filters results to exclude those that match any of the specified floats.
+  """
+  notIn: [Float!]
+}
 
 """
 A field whose value is a JSON Web Token (JWT): https://jwt.io/introduction.
@@ -53,10 +175,22 @@ type Mutation {
     input: CreateUserInput!
   ): User
 
+  """Creates a new wallet for the authenticated user."""
+  createWallet(
+    """The data required to create a new wallet."""
+    input: CreateWalletInput!
+  ): Wallet
+
   """
   Delete the current user within the application. Requires authentication.
   """
   deleteUser: User
+
+  """Delete an existing wallet of the authenticated user."""
+  deleteWallet(
+    """The ID of the wallet to delete."""
+    id: Cuid!
+  ): Wallet
 
   """
   Authenticate a user using their credentials and return access and refresh tokens.
@@ -81,11 +215,114 @@ type Mutation {
     """The data required to update an existing user."""
     input: UpdateUserInput!
   ): User
+
+  """Update an existing wallet of the authenticated user."""
+  updateWallet(
+    """The ID of the wallet to update."""
+    id: Cuid!
+
+    """The data required to update an existing wallet."""
+    input: UpdateWalletInput!
+  ): Wallet
 }
 
 type Query {
   """Get the current user within the application. Requires authentication."""
   me: User
+
+  """Retrieves a wallet by its ID of the authenticated user."""
+  wallet(
+    """The ID of the wallet to retrieve."""
+    id: Cuid!
+  ): Wallet
+
+  """Retrieves all wallets of the authenticated user."""
+  wallets(
+    """The order in which to sort the fetched wallets."""
+    orderBy: [WalletOrderByInput!]
+
+    """
+    The number of wallets to skip before starting to collect the result set.
+    """
+    skip: Int
+
+    """
+    The number of wallets to fetch. If not specified, all matcing wallets will be fetched.
+    """
+    take: Int
+
+    """Filter criteria to determine which wallets to fetch."""
+    where: WalletWhereInput
+  ): WalletPagination!
+}
+
+"""
+Defines the mode for filtering strings, either default or case-insensitive.
+"""
+enum QueryMode {
+  default
+  insensitive
+}
+
+"""Specifies the order of sorting: ascending (asc) or descending (desc)."""
+enum SortOrder {
+  asc
+  desc
+}
+
+"""Defines the criteria for filtering results based on string values."""
+input StringFilter {
+  """Filters results to include those that contain the specified substring."""
+  contains: String
+
+  """Filters results to include those that end with the specified string."""
+  endsWith: String
+
+  """Filters results to only include those that match this exact string."""
+  equals: String
+
+  """
+  Filters results to only include those that are greater than the specified string.
+  """
+  gt: String
+
+  """
+  Filters results to only include those that are greater than or equal to the specified string.
+  """
+  gte: String
+
+  """
+  Filters results to only include those that match any of the specified strings.
+  """
+  in: [String!]
+
+  """
+  Filters results to only include those that are less than the specified string.
+  """
+  lt: String
+
+  """
+  Filters results to only include those that are less than or equal to the specified string.
+  """
+  lte: String
+
+  """
+  Defines the mode for filtering strings, either default or case-insensitive.
+  """
+  mode: QueryMode
+
+  """
+  Allows for nested string filtering, applying additional filter criteria.
+  """
+  not: StringFilter
+
+  """
+  Filters results to exclude those that match any of the specified strings.
+  """
+  notIn: [String!]
+
+  """Filters results to include those that start with the specified string."""
+  startsWith: String
 }
 
 """The Tokens object represents the access and refresh tokens."""
@@ -117,6 +354,16 @@ input UpdateUserInput {
   password: String
 }
 
+"""
+Defines the data required to update an existing wallet within the application.
+"""
+input UpdateWalletInput {
+  """
+  The name of the wallet. This field must be unique within the wallet table. It is optional and will only be validated if provided.
+  """
+  name: String
+}
+
 """The User object represents a registered user within the application."""
 type User {
   """
@@ -143,4 +390,124 @@ type User {
   The last update timestamp of the user account. This field records the most recent date and time when the user's information was modified.
   """
   updatedAt: DateTime!
+}
+
+"""
+The Wallet object represents a registered wallet within the application.
+"""
+type Wallet {
+  """
+  The creation timestamp of the wallet. This field records the exact date and time when the wallet was created.
+  """
+  createdAt: DateTime!
+
+  """The currency that the wallet will use."""
+  currency: Currencies!
+
+  """The currency that the wallet will use."""
+  currentBalance: Float!
+
+  """
+  The unique identifier (ID) of the wallet. This is a unique string assigned to each wallet upon creation and is used for wallet identification within the application.
+  """
+  id: Cuid!
+
+  """
+  The name of the wallet. This field must be unique within the wallet table.
+  """
+  name: String!
+
+  """
+  The last update timestamp of the wallet. This field records the most recent date and time when the wallet's information was modified.
+  """
+  updatedAt: DateTime!
+
+  """
+  The unique identifier (ID) of the user who owns the wallet. This is a unique string assigned to each user upon registration and is used for user identification within the application.
+  """
+  userId: Cuid!
+}
+
+"""
+The wallet order input object represents the criteria by which to sort wallets.
+"""
+input WalletOrderByInput {
+  """
+  The order in which to sort the wallet by the date and time they were created.
+  """
+  createdAt: SortOrder
+
+  """The order in which to sort the wallet by their currency."""
+  currency: SortOrder
+
+  """The order in which to sort the wallet by their current balance."""
+  currentBalance: SortOrder
+
+  """The order in which to sort the wallet by their ID."""
+  id: SortOrder
+
+  """The order in which to sort the wallet by their name."""
+  name: SortOrder
+
+  """
+  The order in which to sort the wallet by the date and time they were last updated.
+  """
+  updatedAt: SortOrder
+}
+
+"""
+Tge WalletPagination object represents a paginated list of wallets within the application.
+"""
+type WalletPagination {
+  """
+  Retrieve a list of wallets within the application. This field returns an array of wallets based on the provided query arguments.
+  """
+  nodes: [Wallet!]!
+
+  """
+  Retrieve the total count of wallets within the application. This field returns the total number of wallets based on the provided query arguments.
+  """
+  totalCount: Int!
+}
+
+"""
+The wallet where input object represents the criteria for filtering wallets.
+"""
+input WalletWhereInput {
+  """
+  A list of conditions that must all be true (logical AND) for the wallet to be included in the results.
+  """
+  AND: [WalletWhereInput!]
+
+  """
+  A list of conditions that must all be false (logical NOT) for the wallet to be included in the results.
+  """
+  NOT: [WalletWhereInput!]
+
+  """
+  A list of conditions where at least one must be true (logical OR) for the wallet to be included in the results.
+  """
+  OR: [WalletWhereInput!]
+
+  """
+  A filter to apply to the createdAt field, filtering by the date and time the wallet was created.
+  """
+  createdAt: DateTimeFilter
+
+  """A filter to apply to the wallet currency field."""
+  currency: EnumCurrenciesFilter
+
+  """A filter to apply to the wallet current balance field."""
+  currentBalance: FloatFilter
+
+  """A filter to apply to the wallet ID field."""
+  id: StringFilter
+
+  """A filter to apply to the wallet name field."""
+  name: StringFilter
+
+  """
+  A filter to apply to the updatedAt field, filtering by the date and time the wallet was last updated.
+  """
+  updatedAt: DateTimeFilter
 }

--- a/apps/api/src/wallets/dto/create-wallet.dto.ts
+++ b/apps/api/src/wallets/dto/create-wallet.dto.ts
@@ -1,0 +1,40 @@
+import { ArgsType, Field, Float, InputType } from '@nestjs/graphql'
+import { Type } from 'class-transformer'
+import { IsNumber, ValidateIf, ValidateNested } from 'class-validator'
+
+import { Currencies } from '@/common/dto/currencies.dto'
+
+@InputType({
+  description:
+    'Defines the data required to create a new wallet within the application.'
+})
+export class CreateWalletInput {
+  @Field(() => String, {
+    description:
+      'The name of the wallet. This field must be unique within the wallet table.'
+  })
+  name: string
+
+  @Field(() => Currencies, {
+    description: 'The currency that the wallet will use.'
+  })
+  currency: keyof typeof Currencies
+
+  @Field(() => Float, {
+    nullable: true,
+    description: 'The balance of the wallet. Defaults to 0.'
+  })
+  @IsNumber()
+  @ValidateIf((_, v) => v !== undefined)
+  currentBalance?: number
+}
+
+@ArgsType()
+export class CreateWalletArgs {
+  @Field(() => CreateWalletInput, {
+    description: 'The data required to create a new wallet.'
+  })
+  @Type(() => CreateWalletInput)
+  @ValidateNested()
+  input: CreateWalletInput
+}

--- a/apps/api/src/wallets/dto/delete-wallet.dto.ts
+++ b/apps/api/src/wallets/dto/delete-wallet.dto.ts
@@ -1,0 +1,10 @@
+import { ArgsType, Field } from '@nestjs/graphql'
+import { GraphQLCuid } from 'graphql-scalars'
+
+@ArgsType()
+export class DeleteWalletArgs {
+  @Field(() => GraphQLCuid, {
+    description: 'The ID of the wallet to delete.'
+  })
+  id: string
+}

--- a/apps/api/src/wallets/dto/find-many-wallet.dto.ts
+++ b/apps/api/src/wallets/dto/find-many-wallet.dto.ts
@@ -1,0 +1,161 @@
+import { ArgsType, Field, InputType, Int } from '@nestjs/graphql'
+import { Transform } from 'class-transformer'
+
+import { EnumCurrenciesFilter } from '@/common/dto/currencies.dto'
+import {
+  DateTimeFilter,
+  FloatFilter,
+  SortOrder,
+  StringFilter
+} from '@/common/dto/prisma.dto'
+
+@InputType({
+  description:
+    'The wallet where input object represents the criteria for filtering wallets.'
+})
+export class WalletWhereInput {
+  @Field(() => [WalletWhereInput], {
+    nullable: true,
+    description:
+      'A list of conditions that must all be true (logical AND) for the wallet to be included in the results.'
+  })
+  AND?: WalletWhereInput[]
+
+  @Field(() => [WalletWhereInput], {
+    nullable: true,
+    description:
+      'A list of conditions where at least one must be true (logical OR) for the wallet to be included in the results.'
+  })
+  OR?: WalletWhereInput[]
+
+  @Field(() => [WalletWhereInput], {
+    nullable: true,
+    description:
+      'A list of conditions that must all be false (logical NOT) for the wallet to be included in the results.'
+  })
+  NOT?: WalletWhereInput[]
+
+  @Field(() => StringFilter, {
+    nullable: true,
+    description: 'A filter to apply to the wallet ID field.'
+  })
+  id?: StringFilter
+
+  @Field(() => StringFilter, {
+    nullable: true,
+    description: 'A filter to apply to the wallet name field.'
+  })
+  name?: StringFilter
+
+  @Field(() => EnumCurrenciesFilter, {
+    nullable: true,
+    description: 'A filter to apply to the wallet currency field.'
+  })
+  currency?: EnumCurrenciesFilter
+
+  @Field(() => FloatFilter, {
+    nullable: true,
+    description: 'A filter to apply to the wallet current balance field.'
+  })
+  currentBalance?: FloatFilter
+
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+    description:
+      'A filter to apply to the createdAt field, filtering by the date and time the wallet was created.'
+  })
+  createdAt?: DateTimeFilter
+
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+    description:
+      'A filter to apply to the updatedAt field, filtering by the date and time the wallet was last updated.'
+  })
+  updatedAt?: DateTimeFilter
+}
+
+@InputType({
+  description:
+    'The wallet order input object represents the criteria by which to sort wallets.'
+})
+export class WalletOrderByInput {
+  @Field(() => SortOrder, {
+    nullable: true,
+    description: 'The order in which to sort the wallet by their ID.'
+  })
+  id?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, {
+    nullable: true,
+    description: 'The order in which to sort the wallet by their name.'
+  })
+  name?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, {
+    nullable: true,
+    description: 'The order in which to sort the wallet by their currency.'
+  })
+  currency?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, {
+    nullable: true,
+    description:
+      'The order in which to sort the wallet by their current balance.'
+  })
+  currentBalance?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, {
+    nullable: true,
+    description:
+      'The order in which to sort the wallet by the date and time they were created.'
+  })
+  createdAt?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, {
+    nullable: true,
+    description:
+      'The order in which to sort the wallet by the date and time they were last updated.'
+  })
+  updatedAt?: keyof typeof SortOrder
+}
+
+@ArgsType()
+export class FindManyWalletArgs {
+  @Field(() => WalletWhereInput, {
+    nullable: true,
+    description: 'Filter criteria to determine which wallets to fetch.'
+  })
+  @Transform(({ value }: { value?: WalletWhereInput | null }) =>
+    value === null ? undefined : value
+  )
+  where?: WalletWhereInput
+
+  @Field(() => [WalletOrderByInput], {
+    nullable: true,
+    description: 'The order in which to sort the fetched wallets.'
+  })
+  @Transform(({ value }: { value?: WalletOrderByInput | null }) =>
+    value === null ? undefined : value
+  )
+  orderBy?: WalletOrderByInput[]
+
+  @Field(() => Int, {
+    nullable: true,
+    description:
+      'The number of wallets to fetch. If not specified, all matcing wallets will be fetched.'
+  })
+  @Transform(({ value }: { value?: number | null }) =>
+    value === null ? undefined : value
+  )
+  take?: number
+
+  @Field(() => Int, {
+    nullable: true,
+    description:
+      'The number of wallets to skip before starting to collect the result set.'
+  })
+  @Transform(({ value }: { value?: number | null }) =>
+    value === null ? undefined : value
+  )
+  skip?: number
+}

--- a/apps/api/src/wallets/dto/find-unique-wallet.dto.ts
+++ b/apps/api/src/wallets/dto/find-unique-wallet.dto.ts
@@ -1,0 +1,10 @@
+import { ArgsType, Field } from '@nestjs/graphql'
+import { GraphQLCuid } from 'graphql-scalars'
+
+@ArgsType()
+export class FindUniqueWalletArgs {
+  @Field(() => GraphQLCuid, {
+    description: 'The ID of the wallet to retrieve.'
+  })
+  id: string
+}

--- a/apps/api/src/wallets/dto/update-wallet.dto.ts
+++ b/apps/api/src/wallets/dto/update-wallet.dto.ts
@@ -1,0 +1,33 @@
+import { ArgsType, Field, InputType } from '@nestjs/graphql'
+import { Type } from 'class-transformer'
+import { ValidateIf, ValidateNested } from 'class-validator'
+import { GraphQLCuid } from 'graphql-scalars'
+
+@InputType({
+  description:
+    'Defines the data required to update an existing wallet within the application.'
+})
+export class UpdateWalletInput {
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'The name of the wallet. This field must be unique within the wallet table. It is optional and will only be validated if provided.'
+  })
+  @ValidateIf((_, value) => value !== undefined)
+  name?: string
+}
+
+@ArgsType()
+export class UpdateWalletArgs {
+  @Field(() => GraphQLCuid, {
+    description: 'The ID of the wallet to update.'
+  })
+  id: string
+
+  @Field(() => UpdateWalletInput, {
+    description: 'The data required to update an existing wallet.'
+  })
+  @Type(() => UpdateWalletInput)
+  @ValidateNested()
+  input: UpdateWalletInput
+}

--- a/apps/api/src/wallets/entities/wallet-pagination.entity.ts
+++ b/apps/api/src/wallets/entities/wallet-pagination.entity.ts
@@ -1,0 +1,7 @@
+import { ObjectType } from '@nestjs/graphql'
+
+@ObjectType({
+  description:
+    'Tge WalletPagination object represents a paginated list of wallets within the application.'
+})
+export class WalletPagination {}

--- a/apps/api/src/wallets/entities/wallet.entity.ts
+++ b/apps/api/src/wallets/entities/wallet.entity.ts
@@ -1,0 +1,51 @@
+import { Field, Float, ObjectType } from '@nestjs/graphql'
+import { Wallet as PrismaWallet } from '@prisma/client'
+import { GraphQLCuid } from 'graphql-scalars'
+
+import { Currencies } from '@/common/dto/currencies.dto'
+
+@ObjectType({
+  description:
+    'The Wallet object represents a registered wallet within the application.'
+})
+export class Wallet implements Partial<PrismaWallet> {
+  @Field(() => GraphQLCuid, {
+    description:
+      'The unique identifier (ID) of the wallet. This is a unique string assigned to each wallet upon creation and is used for wallet identification within the application.'
+  })
+  id: string
+
+  @Field(() => String, {
+    description:
+      'The name of the wallet. This field must be unique within the wallet table.'
+  })
+  name: string
+
+  @Field(() => Currencies, {
+    description: 'The currency that the wallet will use.'
+  })
+  currency: keyof typeof Currencies
+
+  @Field(() => Float, {
+    description: 'The currency that the wallet will use.'
+  })
+  currentBalance: number
+
+  @Field(() => Date, {
+    description:
+      'The creation timestamp of the wallet. This field records the exact date and time when the wallet was created.'
+  })
+  createdAt: Date
+
+  @Field(() => Date, {
+    description:
+      "The last update timestamp of the wallet. This field records the most recent date and time when the wallet's information was modified."
+  })
+  updatedAt: Date
+
+  @Field(() => GraphQLCuid, {
+    description:
+      'The unique identifier (ID) of the user who owns the wallet. This is a unique string assigned to each user upon registration and is used for user identification within the application.'
+  })
+  userId: string
+}

--- a/apps/api/src/wallets/fields/wallet-pagination-fields.resolver.ts
+++ b/apps/api/src/wallets/fields/wallet-pagination-fields.resolver.ts
@@ -1,0 +1,40 @@
+import { UseGuards } from '@nestjs/common'
+import { Int, ResolveField, Resolver } from '@nestjs/graphql'
+import { User } from '@prisma/client'
+
+import { GqlAuthGuard } from '@/auth/guards/gql-auth.guard'
+import { CurrentUser } from '@/common/decorators/current-user.decorator'
+import { ParentArgs } from '@/common/decorators/parent-args.decorator'
+import { FindManyWalletArgs } from '../dto/find-many-wallet.dto'
+import { WalletPagination } from '../entities/wallet-pagination.entity'
+import { Wallet } from '../entities/wallet.entity'
+import { WalletsService } from '../wallets.service'
+
+@Resolver(() => WalletPagination)
+export class WalletPaginationFieldsResolver {
+  constructor(private readonly walletsService: WalletsService) {}
+
+  @UseGuards(GqlAuthGuard)
+  @ResolveField(() => [Wallet], {
+    description:
+      'Retrieve a list of wallets within the application. This field returns an array of wallets based on the provided query arguments.'
+  })
+  nodes(
+    @ParentArgs(FindManyWalletArgs) args: FindManyWalletArgs,
+    @CurrentUser() currentUser: User
+  ): Promise<Wallet[]> {
+    return this.walletsService.findMany(currentUser.id, args)
+  }
+
+  @UseGuards(GqlAuthGuard)
+  @ResolveField(() => Int, {
+    description:
+      'Retrieve the total count of wallets within the application. This field returns the total number of wallets based on the provided query arguments.'
+  })
+  totalCount(
+    @ParentArgs(FindManyWalletArgs) args: FindManyWalletArgs,
+    @CurrentUser() currentUser: User
+  ): Promise<number> {
+    return this.walletsService.count(currentUser.id, args.where)
+  }
+}

--- a/apps/api/src/wallets/wallets.module.ts
+++ b/apps/api/src/wallets/wallets.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+
+import { WalletPaginationFieldsResolver } from './fields/wallet-pagination-fields.resolver'
+import { WalletsResolver } from './wallets.resolver'
+import { WalletsService } from './wallets.service'
+
+@Module({
+  providers: [WalletsService, WalletsResolver, WalletPaginationFieldsResolver]
+})
+export class WalletsModule {}

--- a/apps/api/src/wallets/wallets.resolver.ts
+++ b/apps/api/src/wallets/wallets.resolver.ts
@@ -1,0 +1,93 @@
+import { NotFoundException, UseGuards } from '@nestjs/common'
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql'
+import { User } from '@prisma/client'
+
+import { GqlAuthGuard } from '@/auth/guards/gql-auth.guard'
+import { CurrentUser } from '@/common/decorators/current-user.decorator'
+import { CreateWalletArgs } from './dto/create-wallet.dto'
+import { DeleteWalletArgs } from './dto/delete-wallet.dto'
+import { FindManyWalletArgs } from './dto/find-many-wallet.dto'
+import { FindUniqueWalletArgs } from './dto/find-unique-wallet.dto'
+import { UpdateWalletArgs } from './dto/update-wallet.dto'
+import { WalletPagination } from './entities/wallet-pagination.entity'
+import { Wallet } from './entities/wallet.entity'
+import { WalletsService } from './wallets.service'
+
+@Resolver()
+export class WalletsResolver {
+  constructor(private readonly walletsService: WalletsService) {}
+
+  @UseGuards(GqlAuthGuard)
+  @Mutation(() => Wallet, {
+    nullable: true,
+    description: 'Creates a new wallet for the authenticated user.'
+  })
+  async createWallet(
+    @Args() args: CreateWalletArgs,
+    @CurrentUser() currentUser: User
+  ): Promise<Wallet> {
+    return this.walletsService.create({
+      ...args.input,
+      user: { connect: { id: currentUser.id } }
+    })
+  }
+
+  @UseGuards(GqlAuthGuard)
+  @Mutation(() => Wallet, {
+    nullable: true,
+    description: 'Update an existing wallet of the authenticated user.'
+  })
+  async updateWallet(
+    @Args() args: UpdateWalletArgs,
+    @CurrentUser() currentUser: User
+  ): Promise<Wallet> {
+    const wallet = await this.walletsService.findUnique(
+      { id: args.id },
+      currentUser.id
+    )
+
+    if (!wallet) throw new NotFoundException('Wallet not found')
+
+    return this.walletsService.update(args.id, args.input)
+  }
+
+  @UseGuards(GqlAuthGuard)
+  @Mutation(() => Wallet, {
+    nullable: true,
+    description: 'Delete an existing wallet of the authenticated user.'
+  })
+  async deleteWallet(
+    @Args() args: DeleteWalletArgs,
+    @CurrentUser() currentUser: User
+  ): Promise<Wallet> {
+    const wallet = await this.walletsService.findUnique(
+      { id: args.id },
+      currentUser.id
+    )
+
+    if (!wallet) throw new NotFoundException('Wallet not found')
+
+    return this.walletsService.delete(args.id)
+  }
+
+  @UseGuards(GqlAuthGuard)
+  @Query(() => Wallet, {
+    nullable: true,
+    name: 'wallet',
+    description: 'Retrieves a wallet by its ID of the authenticated user.'
+  })
+  async getWallet(
+    @Args() args: FindUniqueWalletArgs,
+    @CurrentUser() currentUser: User
+  ): Promise<Wallet | null> {
+    return this.walletsService.findUnique({ id: args.id }, currentUser.id)
+  }
+
+  @UseGuards(GqlAuthGuard)
+  @Query(() => WalletPagination, {
+    description: 'Retrieves all wallets of the authenticated user.'
+  })
+  wallets(@Args() _args: FindManyWalletArgs): boolean {
+    return true
+  }
+}

--- a/apps/api/src/wallets/wallets.resolver.ts
+++ b/apps/api/src/wallets/wallets.resolver.ts
@@ -1,4 +1,4 @@
-import { NotFoundException, UseGuards } from '@nestjs/common'
+import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql'
 import { User } from '@prisma/client'
 
@@ -41,14 +41,7 @@ export class WalletsResolver {
     @Args() args: UpdateWalletArgs,
     @CurrentUser() currentUser: User
   ): Promise<Wallet> {
-    const wallet = await this.walletsService.findUnique(
-      { id: args.id },
-      currentUser.id
-    )
-
-    if (!wallet) throw new NotFoundException('Wallet not found')
-
-    return this.walletsService.update(args.id, args.input)
+    return this.walletsService.update(args.id, currentUser.id, args.input)
   }
 
   @UseGuards(GqlAuthGuard)
@@ -60,14 +53,7 @@ export class WalletsResolver {
     @Args() args: DeleteWalletArgs,
     @CurrentUser() currentUser: User
   ): Promise<Wallet> {
-    const wallet = await this.walletsService.findUnique(
-      { id: args.id },
-      currentUser.id
-    )
-
-    if (!wallet) throw new NotFoundException('Wallet not found')
-
-    return this.walletsService.delete(args.id)
+    return this.walletsService.delete(args.id, currentUser.id)
   }
 
   @UseGuards(GqlAuthGuard)
@@ -76,7 +62,7 @@ export class WalletsResolver {
     name: 'wallet',
     description: 'Retrieves a wallet by its ID of the authenticated user.'
   })
-  async getWallet(
+  async findUniqueWallet(
     @Args() args: FindUniqueWalletArgs,
     @CurrentUser() currentUser: User
   ): Promise<Wallet | null> {
@@ -85,9 +71,10 @@ export class WalletsResolver {
 
   @UseGuards(GqlAuthGuard)
   @Query(() => WalletPagination, {
+    name: 'wallets',
     description: 'Retrieves all wallets of the authenticated user.'
   })
-  wallets(@Args() _args: FindManyWalletArgs): boolean {
+  findManyWallet(@Args() _args: FindManyWalletArgs): boolean {
     return true
   }
 }

--- a/apps/api/src/wallets/wallets.service.ts
+++ b/apps/api/src/wallets/wallets.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common'
+import { Prisma, Wallet } from '@prisma/client'
+import { PrismaService } from 'nestjs-prisma'
+
+import { UpdateWalletInput } from './dto/update-wallet.dto'
+
+@Injectable()
+export class WalletsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(input: Prisma.WalletCreateInput): Promise<Wallet> {
+    return this.prisma.wallet.create({ data: input })
+  }
+
+  async findUnique(
+    where: Prisma.WalletWhereUniqueInput,
+    currentUserId: string
+  ): Promise<Wallet | null> {
+    return this.prisma.wallet.findUnique({
+      where: {
+        ...where,
+        userId: currentUserId
+      }
+    })
+  }
+
+  async findMany(
+    currentUserId: string,
+    args?: Prisma.WalletFindManyArgs
+  ): Promise<Wallet[]> {
+    return this.prisma.wallet.findMany({
+      ...args,
+      where: {
+        AND: [{ ...args?.where }, { userId: currentUserId }]
+      }
+    })
+  }
+
+  async count(
+    currentUserId: string,
+    where?: Prisma.WalletWhereInput
+  ): Promise<number> {
+    return this.prisma.wallet.count({
+      where: {
+        AND: [{ ...where }, { userId: currentUserId }]
+      }
+    })
+  }
+
+  async update(id: string, input: UpdateWalletInput): Promise<Wallet> {
+    return this.prisma.wallet.update({
+      where: { id },
+      data: input
+    })
+  }
+
+  async delete(id: string): Promise<Wallet> {
+    return this.prisma.wallet.delete({ where: { id } })
+  }
+}

--- a/apps/api/src/wallets/wallets.service.ts
+++ b/apps/api/src/wallets/wallets.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, NotFoundException } from '@nestjs/common'
 import { Prisma, Wallet } from '@prisma/client'
 import { PrismaService } from 'nestjs-prisma'
 
@@ -47,14 +47,30 @@ export class WalletsService {
     })
   }
 
-  async update(id: string, input: UpdateWalletInput): Promise<Wallet> {
+  async update(
+    id: string,
+    currentUserId: string,
+    input: UpdateWalletInput
+  ): Promise<Wallet> {
+    const wallet = await this.prisma.wallet.findUnique({
+      where: { id, userId: currentUserId }
+    })
+
+    if (!wallet) throw new NotFoundException('Wallet not found')
+
     return this.prisma.wallet.update({
       where: { id },
       data: input
     })
   }
 
-  async delete(id: string): Promise<Wallet> {
+  async delete(id: string, currentUserId: string): Promise<Wallet> {
+    const wallet = await this.prisma.wallet.findUnique({
+      where: { id, userId: currentUserId }
+    })
+
+    if (!wallet) throw new NotFoundException('Wallet not found')
+
     return this.prisma.wallet.delete({ where: { id } })
   }
 }


### PR DESCRIPTION
J'ai bien ajouté le système de wallets comme demandé à l'issue #6 

Il est donc possible de créer plusieurs wallet pour un utilisateur. Il est obligatoire d'être connecté pour effectuer des actions sur des wallets. Les actions peuvent être effectué que sur nos propres wallets, et pareil pour les visualiser.
Lors de la création il faut renseigner le nom et la devise du wallet. La valeur est optionnelle, si elle n'est pas renseigné, elle est à 0 par défaut (direct en base de données).
On peut update ses wallets, mais uniquement le nom.

Il est aussi possible de récupérer ses wallets, sois via la query `wallet` qui demande l'id du wallet, sois via `wallets` qui renvoie une système de pagination.
Pour la pagination il est possible de filtrer un maximum la recherche des wallets via des arguments/inputs. Il renvoie 2 champs `nodes` et `totalCount`. Ils sont indépendants, ce qui veut dire que si je mets que le champ `totalCount` il ne va pas aller fetch les données des wallets et donc faire juste un `count` en base de données. Cela permet de gagner en performance si l'utilisateur a plusieurs wallets.
Cette base de CRUD va être très utile pour la suite, car j'ai créer un fichier `prisma.dto.ts` dans le module common, qui va être utilisé dans tous les systèmes de pagination. Pour la création d'autres CRUD, celui-ci peut être une source d'inspiration pour aider.

Je compte sur vous pour tester cette branche en local avant de confirmer la review de code, pour que vous ayez compris le code et le fonctionnement. Si vous avez des questions: Discord ou commentaire dans cette PR.

> [!NOTE]
> Une nouvelle migration a été ajouté à prisma. Faire attention à migrer avant de faire des tests.