### PR TITLE
fix(🚧 ): import react

### DIFF
--- a/apps/application/app/(tabs)/about.tsx
+++ b/apps/application/app/(tabs)/about.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { SafeAreaView, Text } from 'react-native'
 
 export default function AboutScreen() {

--- a/apps/application/app/(tabs)/index.tsx
+++ b/apps/application/app/(tabs)/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { SafeAreaView, Text } from 'react-native'
 
 export default function HomeScreen() {

--- a/apps/application/app/+html.tsx
+++ b/apps/application/app/+html.tsx
@@ -1,5 +1,7 @@
 import { ScrollViewStyleReset } from 'expo-router/html'
-import { type PropsWithChildren } from 'react'
+import React from 'react'
+
+import type { PropsWithChildren } from 'react'
 
 /**
  * This file is web-only and used to configure the root HTML for every web page during static rendering.

--- a/apps/application/app/+not-found.tsx
+++ b/apps/application/app/+not-found.tsx
@@ -1,4 +1,5 @@
 import { Link, Stack } from 'expo-router'
+import React from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 
 export default function NotFoundScreen() {

--- a/apps/application/app/_layout.tsx
+++ b/apps/application/app/_layout.tsx
@@ -1,4 +1,5 @@
 import { Stack } from 'expo-router'
+import React from 'react'
 
 export default function RootLayout() {
   return (

--- a/apps/application/package.json
+++ b/apps/application/package.json
@@ -12,6 +12,7 @@
     "lint": "expo lint"
   },
   "dependencies": {
+    "@babel/runtime": "^7.24.7",
     "@expo/vector-icons": "^14.0.2",
     "@react-navigation/native": "^6.1.17",
     "expo": "~51.0.14",

--- a/apps/application/tsconfig.json
+++ b/apps/application/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    "jsx": "react",
     "strict": true,
     "paths": {
       "@/*": ["./*"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
 
   apps/application:
     dependencies:
+      '@babel/runtime':
+        specifier: ^7.24.7
+        version: 7.24.7
       '@expo/vector-icons':
         specifier: ^14.0.2
         version: 14.0.2
@@ -1121,6 +1124,10 @@ packages:
 
   '@babel/runtime@7.23.2':
     resolution: {integrity: sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.24.7':
+    resolution: {integrity: sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.24.7':
@@ -8218,6 +8225,10 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.0
 
+  '@babel/runtime@7.24.7':
+    dependencies:
+      regenerator-runtime: 0.14.0
+
   '@babel/template@7.24.7':
     dependencies:
       '@babel/code-frame': 7.24.7
@@ -8402,7 +8413,7 @@ snapshots:
 
   '@expo/cli@0.18.19(expo-modules-autolinking@1.11.1)':
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.24.7
       '@expo/code-signing-certificates': 0.0.5
       '@expo/config': 9.0.2
       '@expo/config-plugins': 8.0.5
@@ -9290,12 +9301,12 @@ snapshots:
 
   '@radix-ui/react-compose-refs@1.0.0(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.24.7
       react: 18.2.0
 
   '@radix-ui/react-slot@1.0.1(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.24.7
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       react: 18.2.0
 
@@ -11893,7 +11904,7 @@ snapshots:
 
   expo@51.0.14(@babel/core@7.24.7)(@babel/preset-env@7.24.7(@babel/core@7.24.7)):
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.24.7
       '@expo/cli': 0.18.19(expo-modules-autolinking@1.11.1)
       '@expo/config': 9.0.1
       '@expo/config-plugins': 8.0.5
@@ -13607,7 +13618,7 @@ snapshots:
 
   metro-runtime@0.80.9:
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.24.7
 
   metro-source-map@0.80.9:
     dependencies:
@@ -14390,7 +14401,7 @@ snapshots:
 
   react-native-web@0.19.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.24.7
       '@react-native/normalize-colors': 0.74.84
       fbjs: 3.0.5
       inline-style-prefixer: 6.0.4


### PR DESCRIPTION
Problème résolu : Correction d'erreurs d'import manquants lors de l'initialisation du projet.

Détails des modifications :

Ajout des imports manquants pour React, ce qui corrige les erreurs survenues lors de l'initialisation du projet.
Tests effectués :

Vérification manuelle que le projet s'initialise correctement après ajout des imports.