### PR TITLE
Feature: ajout du module des transactions

### DIFF
--- a/apps/api/prisma/migrations/20240624081519_create_transaction_table/migration.sql
+++ b/apps/api/prisma/migrations/20240624081519_create_transaction_table/migration.sql
@@ -1,0 +1,19 @@
+-- CreateEnum
+CREATE TYPE "TransactionType" AS ENUM ('INCOME', 'EXPENSE');
+
+-- CreateTable
+CREATE TABLE "transaction" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "type" "TransactionType" NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "wallet_id" TEXT NOT NULL,
+
+    CONSTRAINT "transaction_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "transaction" ADD CONSTRAINT "transaction_wallet_id_fkey" FOREIGN KEY ("wallet_id") REFERENCES "wallet"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -15,6 +15,11 @@ enum Currencies {
   RUB
 }
 
+enum TransactionType {
+  INCOME
+  EXPENSE
+}
+
 model User {
   id       String  @id @default(cuid())
   email    String  @unique
@@ -41,5 +46,23 @@ model Wallet {
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId String @map("user_id")
 
+  transactions Transaction[]
+
   @@map("wallet")
+}
+
+model Transaction {
+  id     String          @id @default(cuid())
+  title  String
+  amount Float
+  date   DateTime
+  type   TransactionType
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  wallet   Wallet @relation(fields: [walletId], references: [id], onDelete: Cascade)
+  walletId String @map("wallet_id")
+
+  @@map("transaction")
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuthModule } from './auth/auth.module'
 import { AppAuthGuard } from './auth/guards/app-auth.guard'
 import { CommonModule } from './common/common.module'
 import config from './common/config/config'
+import { TransactionsModule } from './transactions/transactions.module'
 import { UsersModule } from './users/users.module'
 import { WalletsModule } from './wallets/wallets.module'
 
@@ -52,7 +53,8 @@ import type { HttpException } from '@nestjs/common'
     CommonModule,
     UsersModule,
     AuthModule,
-    WalletsModule
+    WalletsModule,
+    TransactionsModule
   ],
   providers: [
     {

--- a/apps/api/src/common/dto/transaction-type.dto.ts
+++ b/apps/api/src/common/dto/transaction-type.dto.ts
@@ -1,0 +1,38 @@
+import { Field, InputType, registerEnumType } from '@nestjs/graphql'
+
+export enum TransactionType {
+  EXPENSE = 'EXPENSE',
+  INCOME = 'INCOME'
+}
+
+registerEnumType(TransactionType, {
+  name: 'TransactionType',
+  description: 'The transaction type that can be used within the application.'
+})
+
+@InputType()
+export class EnumTransactionTypeFilter {
+  @Field(() => TransactionType, {
+    nullable: true,
+    description: 'Checks for equality with the specified value.'
+  })
+  equals?: keyof typeof TransactionType;
+
+  @Field(() => [TransactionType], {
+    nullable: true,
+    description: 'Checks for equality with the specified values.'
+  })
+  in?: (keyof typeof TransactionType)[]
+
+  @Field(() => [TransactionType], {
+    nullable: true,
+    description: 'Checks for inequality with the specified values.'
+  })
+  notIn?: (keyof typeof TransactionType)[]
+
+  @Field(() => EnumTransactionTypeFilter, {
+    nullable: true,
+    description: 'Negates the specified condition.'
+  })
+  not?: EnumTransactionTypeFilter
+}

--- a/apps/api/src/graphql/schema.gql
+++ b/apps/api/src/graphql/schema.gql
@@ -2,6 +2,26 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
+"""
+Defines the data required to create a new transaction within the application.
+"""
+input CreateTransactionInput {
+  """The amount of the transaction."""
+  amount: Float!
+
+  """The date of the transaction."""
+  date: DateTime!
+
+  """The title of the transaction."""
+  title: String!
+
+  """The type of transaction."""
+  type: TransactionType!
+
+  """The wallet ID that the transaction belongs to."""
+  walletId: Cuid!
+}
+
 """Defines the data required to create a new user within the application."""
 input CreateUserInput {
   """
@@ -112,6 +132,20 @@ input EnumCurrenciesFilter {
   notIn: [Currencies!]
 }
 
+input EnumTransactionTypeFilter {
+  """Checks for equality with the specified value."""
+  equals: TransactionType
+
+  """Checks for equality with the specified values."""
+  in: [TransactionType!]
+
+  """Negates the specified condition."""
+  not: EnumTransactionTypeFilter
+
+  """Checks for inequality with the specified values."""
+  notIn: [TransactionType!]
+}
+
 input FloatFilter {
   """Filters results to only include those that match this exact float."""
   equals: Float
@@ -169,6 +203,12 @@ input LoginInput {
 }
 
 type Mutation {
+  """Create a new transaction within the application."""
+  createTransaction(
+    """The data required to create a new transaction."""
+    input: CreateTransactionInput!
+  ): Transaction!
+
   """Create a new user within the application."""
   createUser(
     """The data required to create a new user."""
@@ -180,6 +220,12 @@ type Mutation {
     """The data required to create a new wallet."""
     input: CreateWalletInput!
   ): Wallet
+
+  """Delete an existing transaction within the application."""
+  deleteTransaction(
+    """The ID of the transaction to delete."""
+    id: Cuid!
+  ): Transaction!
 
   """
   Delete the current user within the application. Requires authentication.
@@ -208,6 +254,15 @@ type Mutation {
     refreshToken: JWT!
   ): Tokens
 
+  """Update an existing transaction within the application."""
+  updateTransaction(
+    """The ID of the transaction to update."""
+    id: Cuid!
+
+    """The data required to update an existing transaction."""
+    input: UpdateTransactionInput!
+  ): Transaction!
+
   """
   Update the current user within the application. Requires authentication.
   """
@@ -229,6 +284,31 @@ type Mutation {
 type Query {
   """Get the current user within the application. Requires authentication."""
   me: User
+
+  """Retrieve a single transaction within the application."""
+  transaction(
+    """The ID of the transaction to retrieve."""
+    id: Cuid!
+  ): Transaction
+
+  """Retrieve multiple transactions within the application."""
+  transactions(
+    """The order in which to sort the fetched transactions."""
+    orderBy: [TransactionOrderByInput!]
+
+    """
+    The number of transactions to skip before starting to collect the result set.
+    """
+    skip: Int
+
+    """
+    The number of transactions to fetch. If not specified, all matcing transactions will be fetched.
+    """
+    take: Int
+
+    """Filter criteria to determine which transactions to fetch."""
+    where: TransactionWhereInput
+  ): TransactionPagination
 
   """Retrieves a wallet by its ID of the authenticated user."""
   wallet(
@@ -332,6 +412,161 @@ type Tokens {
 
   """The refresh token used to generate a new access token."""
   refreshToken: JWT!
+}
+
+"""
+The Transaction object represents a registered transaction within the application.
+"""
+type Transaction {
+  """
+  The amount of the transaction. This field represents the monetary value of the transaction.
+  """
+  amount: Float!
+
+  """
+  The creation timestamp of the transaction. This field records the exact date and time when the transaction was created.
+  """
+  createdAt: DateTime!
+
+  """
+  The date of the transaction. This field records the exact date when the transaction occurred.
+  """
+  date: DateTime!
+
+  """
+  The unique identifier (ID) of the transaction. This is a unique string assigned to each transaction upon creation and is used for transaction identification within the application.
+  """
+  id: Cuid!
+
+  """
+  The title of the transaction. This field is used to describe the purpose of the transaction.
+  """
+  title: String!
+
+  """
+  The type of the transaction. This field categorizes the transaction as either an income or an expense.
+  """
+  type: TransactionType!
+
+  """
+  The last update timestamp of the transaction. This field records the most recent date and time when the transaction's information was modified.
+  """
+  updatedAt: DateTime!
+
+  """
+  The unique identifier (ID) of the wallet associated with the transaction. This is a unique string assigned to each wallet upon creation and is used for wallet identification within the application.
+  """
+  walletId: Cuid!
+}
+
+input TransactionOrderByInput {
+  """The order in which to sort the fetched transactions by their amount."""
+  amount: SortOrder
+
+  """
+  The order in which to sort the fetched transactions by the date and time they were created.
+  """
+  createdAt: SortOrder
+
+  """The order in which to sort the fetched transactions by their date."""
+  date: SortOrder
+
+  """The direction in which to sort the fetched transactions."""
+  id: SortOrder
+
+  """The order in which to sort the fetched transactions by their title."""
+  title: SortOrder
+
+  """The order in which to sort the fetched transactions by their type."""
+  type: SortOrder
+
+  """
+  The order in which to sort the fetched transactions by the date and time they were last updated.
+  """
+  updatedAt: SortOrder
+}
+
+"""
+The TransactionPagination object represents a paginated list of transactions within the application.
+"""
+type TransactionPagination {
+  """
+  Retrieve a list of transactions within the application. This field returns an array of transactions based on the provided query arguments.
+  """
+  nodes: [Transaction!]!
+
+  """
+  Retrieve the total count of transactions within the application. This field returns the total number of transactions based on the provided query arguments.
+  """
+  totalCount: Int!
+}
+
+"""The transaction type that can be used within the application."""
+enum TransactionType {
+  EXPENSE
+  INCOME
+}
+
+"""
+The transaction where input object represents the criteria for filtering transactions.
+"""
+input TransactionWhereInput {
+  """
+  A list of conditions that must all be true (logical AND) for the transaction to be included in the results.
+  """
+  AND: [TransactionWhereInput!]
+
+  """
+  A list of conditions that must all be false (logical NOT) for the transaction to be included in the results.
+  """
+  NOT: [TransactionWhereInput!]
+
+  """
+  A list of conditions where at least one must be true (logical OR) for the transaction to be included in the results.
+  """
+  OR: [TransactionWhereInput!]
+
+  """A filter to apply to the transaction amount field."""
+  amount: FloatFilter
+
+  """
+  A filter to apply to the createdAt field, filtering by the date and time the transaction was created.
+  """
+  createdAt: DateTimeFilter
+
+  """A filter to apply to the transaction date field."""
+  date: DateTimeFilter
+
+  """A filter to apply to the transaction ID field."""
+  id: StringFilter
+
+  """A filter to apply to the transaction title field."""
+  title: StringFilter
+
+  """A filter to apply to the transaction type field."""
+  type: EnumTransactionTypeFilter
+
+  """
+  A filter to apply to the updatedAt field, filtering by the date and time the transaction was last updated.
+  """
+  updatedAt: DateTimeFilter
+
+  """A filter to apply to the wallet ID field."""
+  walletId: StringFilter
+}
+
+"""
+Defines the data required to update an existing transaction within the application.
+"""
+input UpdateTransactionInput {
+  """The amount of the transaction."""
+  amount: Float
+
+  """The date of the transaction."""
+  date: DateTime
+
+  """The title of the transaction."""
+  title: String
 }
 
 """
@@ -456,7 +691,7 @@ input WalletOrderByInput {
 }
 
 """
-Tge WalletPagination object represents a paginated list of wallets within the application.
+The WalletPagination object represents a paginated list of wallets within the application.
 """
 type WalletPagination {
   """

--- a/apps/api/src/transactions/dto/create-transaction.dto.ts
+++ b/apps/api/src/transactions/dto/create-transaction.dto.ts
@@ -1,0 +1,59 @@
+import { ArgsType, Field, Float, InputType } from '@nestjs/graphql'
+import { Type } from 'class-transformer'
+import { Min, MinLength, ValidateNested } from 'class-validator'
+import { GraphQLCuid } from 'graphql-scalars'
+
+import { TransactionType } from '@/common/dto/transaction-type.dto'
+
+@InputType({
+  description:
+    'Defines the data required to create a new transaction within the application.'
+})
+export class CreateTransactionInput {
+  @Field(() => String, {
+    description: 'The title of the transaction.'
+  })
+  @MinLength(3, {
+    message: 'The title must be at least 3 characters long.',
+    context: {
+      min: 3
+    }
+  })
+  title: string
+
+  @Field(() => Float, {
+    description: 'The amount of the transaction.'
+  })
+  @Min(0, {
+    message: 'The amount must be greater than or equal to 0.',
+    context: {
+      min: 0
+    }
+  })
+  amount: number
+
+  @Field(() => Date, {
+    description: 'The date of the transaction.'
+  })
+  date: Date
+
+  @Field(() => TransactionType, {
+    description: 'The type of transaction.'
+  })
+  type: keyof typeof TransactionType
+
+  @Field(() => GraphQLCuid, {
+    description: 'The wallet ID that the transaction belongs to.'
+  })
+  walletId: string
+}
+
+@ArgsType()
+export class CreateTransactionArgs {
+  @Field(() => CreateTransactionInput, {
+    description: 'The data required to create a new transaction.'
+  })
+  @Type(() => CreateTransactionInput)
+  @ValidateNested()
+  input: CreateTransactionInput
+}

--- a/apps/api/src/transactions/dto/delete-transaction.dto.ts
+++ b/apps/api/src/transactions/dto/delete-transaction.dto.ts
@@ -1,0 +1,10 @@
+import { ArgsType, Field } from '@nestjs/graphql'
+import { GraphQLCuid } from 'graphql-scalars'
+
+@ArgsType()
+export class DeleteTransactionArgs {
+  @Field(() => GraphQLCuid, {
+    description: 'The ID of the transaction to delete.'
+  })
+  id: string
+}

--- a/apps/api/src/transactions/dto/find-many-transaction.dto.ts
+++ b/apps/api/src/transactions/dto/find-many-transaction.dto.ts
@@ -1,0 +1,179 @@
+import { ArgsType, Field, InputType, Int } from '@nestjs/graphql'
+import { Transform } from 'class-transformer'
+
+import {
+  DateTimeFilter,
+  FloatFilter,
+  SortOrder,
+  StringFilter
+} from '@/common/dto/prisma.dto'
+import { EnumTransactionTypeFilter } from '@/common/dto/transaction-type.dto'
+
+@InputType({
+  description:
+    'The transaction where input object represents the criteria for filtering transactions.'
+})
+export class TransactionWhereInput {
+  @Field(() => [TransactionWhereInput], {
+    nullable: true,
+    description:
+      'A list of conditions that must all be true (logical AND) for the transaction to be included in the results.'
+  })
+  AND?: TransactionWhereInput[]
+
+  @Field(() => [TransactionWhereInput], {
+    nullable: true,
+    description:
+      'A list of conditions where at least one must be true (logical OR) for the transaction to be included in the results.'
+  })
+  OR?: TransactionWhereInput[]
+
+  @Field(() => [TransactionWhereInput], {
+    nullable: true,
+    description:
+      'A list of conditions that must all be false (logical NOT) for the transaction to be included in the results.'
+  })
+  NOT?: TransactionWhereInput[]
+
+  @Field(() => StringFilter, {
+    nullable: true,
+    description: 'A filter to apply to the transaction ID field.'
+  })
+  id?: StringFilter
+
+  @Field(() => StringFilter, {
+    nullable: true,
+    description: 'A filter to apply to the transaction title field.'
+  })
+  title?: StringFilter
+
+  @Field(() => FloatFilter, {
+    nullable: true,
+    description: 'A filter to apply to the transaction amount field.'
+  })
+  amount?: FloatFilter
+
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+    description: 'A filter to apply to the transaction date field.'
+  })
+  date?: DateTimeFilter
+
+  @Field(() => EnumTransactionTypeFilter, {
+    nullable: true,
+    description: 'A filter to apply to the transaction type field.'
+  })
+  type?: EnumTransactionTypeFilter
+
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+    description:
+      'A filter to apply to the createdAt field, filtering by the date and time the transaction was created.'
+  })
+  createdAt?: DateTimeFilter
+
+  @Field(() => DateTimeFilter, {
+    nullable: true,
+    description:
+      'A filter to apply to the updatedAt field, filtering by the date and time the transaction was last updated.'
+  })
+  updatedAt?: DateTimeFilter
+
+  @Field(() => StringFilter, {
+    nullable: true,
+    description: 'A filter to apply to the wallet ID field.'
+  })
+  walletId?: StringFilter
+}
+
+@InputType()
+export class TransactionOrderByInput {
+  @Field(() => SortOrder, {
+    nullable: true,
+    description: 'The direction in which to sort the fetched transactions.'
+  })
+  id?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, {
+    nullable: true,
+    description:
+      'The order in which to sort the fetched transactions by their title.'
+  })
+  title?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, {
+    nullable: true,
+    description:
+      'The order in which to sort the fetched transactions by their amount.'
+  })
+  amount?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, {
+    nullable: true,
+    description:
+      'The order in which to sort the fetched transactions by their date.'
+  })
+  date?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, {
+    nullable: true,
+    description:
+      'The order in which to sort the fetched transactions by their type.'
+  })
+  type?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, {
+    nullable: true,
+    description:
+      'The order in which to sort the fetched transactions by the date and time they were created.'
+  })
+  createdAt?: keyof typeof SortOrder
+
+  @Field(() => SortOrder, {
+    nullable: true,
+    description:
+      'The order in which to sort the fetched transactions by the date and time they were last updated.'
+  })
+  updatedAt?: keyof typeof SortOrder
+}
+
+@ArgsType()
+export class FindManyTransactionArgs {
+  @Field(() => TransactionWhereInput, {
+    nullable: true,
+    description: 'Filter criteria to determine which transactions to fetch.'
+  })
+  @Transform(({ value }: { value?: TransactionWhereInput | null }) =>
+    value === null ? undefined : value
+  )
+  where?: TransactionWhereInput
+
+  @Field(() => [TransactionOrderByInput], {
+    nullable: true,
+    description: 'The order in which to sort the fetched transactions.'
+  })
+  @Transform(({ value }: { value?: TransactionOrderByInput | null }) =>
+    value === null ? undefined : value
+  )
+  orderBy?: TransactionOrderByInput[]
+
+  @Field(() => Int, {
+    nullable: true,
+    description:
+      'The number of transactions to fetch. If not specified, all matcing transactions will be fetched.'
+  })
+  @Transform(({ value }: { value?: number | null }) =>
+    value === null ? undefined : value
+  )
+  take?: number
+
+  @Field(() => Int, {
+    nullable: true,
+    description:
+      'The number of transactions to skip before starting to collect the result set.'
+  })
+  @Transform(({ value }: { value?: number | null }) =>
+    value === null ? undefined : value
+  )
+  skip?: number
+}

--- a/apps/api/src/transactions/dto/find-unique-transaction.dto.ts
+++ b/apps/api/src/transactions/dto/find-unique-transaction.dto.ts
@@ -1,0 +1,10 @@
+import { ArgsType, Field } from '@nestjs/graphql'
+import { GraphQLCuid } from 'graphql-scalars'
+
+@ArgsType()
+export class FindUniqueTransactionArgs {
+  @Field(() => GraphQLCuid, {
+    description: 'The ID of the transaction to retrieve.'
+  })
+  id: string
+}

--- a/apps/api/src/transactions/dto/update-transaction.dto.ts
+++ b/apps/api/src/transactions/dto/update-transaction.dto.ts
@@ -1,0 +1,67 @@
+import { ArgsType, Field, Float, InputType } from '@nestjs/graphql'
+import { Type } from 'class-transformer'
+import {
+  IsDate,
+  Min,
+  MinLength,
+  ValidateIf,
+  ValidateNested
+} from 'class-validator'
+import { GraphQLCuid } from 'graphql-scalars'
+
+@InputType({
+  description:
+    'Defines the data required to update an existing transaction within the application.'
+})
+export class UpdateTransactionInput {
+  @Field(() => String, {
+    nullable: true,
+    description: 'The title of the transaction.'
+  })
+  @MinLength(3, {
+    message: 'The title must be at least 3 characters long.',
+    context: {
+      min: 3
+    }
+  })
+  @ValidateIf((_, value) => value !== undefined)
+  title?: string
+
+  @Field(() => Float, {
+    nullable: true,
+    description: 'The amount of the transaction.'
+  })
+  @Min(0, {
+    message: 'The amount must be greater than or equal to 0.',
+    context: {
+      min: 0
+    }
+  })
+  @ValidateIf((_, value) => value !== undefined)
+  amount?: number
+
+  @Field(() => Date, {
+    nullable: true,
+    description: 'The date of the transaction.'
+  })
+  @IsDate({
+    message: 'The date must be a valid date.'
+  })
+  @ValidateIf((_, value) => value !== undefined)
+  date?: Date
+}
+
+@ArgsType()
+export class UpdateTransactionArgs {
+  @Field(() => GraphQLCuid, {
+    description: 'The ID of the transaction to update.'
+  })
+  id: string
+
+  @Field(() => UpdateTransactionInput, {
+    description: 'The data required to update an existing transaction.'
+  })
+  @Type(() => UpdateTransactionInput)
+  @ValidateNested()
+  input: UpdateTransactionInput
+}

--- a/apps/api/src/transactions/entities/transaction-pagination.entity.ts
+++ b/apps/api/src/transactions/entities/transaction-pagination.entity.ts
@@ -1,0 +1,7 @@
+import { ObjectType } from '@nestjs/graphql'
+
+@ObjectType({
+  description:
+    'The TransactionPagination object represents a paginated list of transactions within the application.'
+})
+export class TransactionPagination {}

--- a/apps/api/src/transactions/entities/transaction.entity.ts
+++ b/apps/api/src/transactions/entities/transaction.entity.ts
@@ -1,0 +1,59 @@
+import { Field, Float, ObjectType } from '@nestjs/graphql'
+import { Transaction as PrismaTransaction } from '@prisma/client'
+import { GraphQLCuid } from 'graphql-scalars'
+
+import { TransactionType } from '@/common/dto/transaction-type.dto'
+
+@ObjectType({
+  description:
+    'The Transaction object represents a registered transaction within the application.'
+})
+export class Transaction implements Partial<PrismaTransaction> {
+  @Field(() => GraphQLCuid, {
+    description:
+      'The unique identifier (ID) of the transaction. This is a unique string assigned to each transaction upon creation and is used for transaction identification within the application.'
+  })
+  id: string
+
+  @Field(() => String, {
+    description:
+      'The title of the transaction. This field is used to describe the purpose of the transaction.'
+  })
+  title: string
+
+  @Field(() => Float, {
+    description:
+      'The amount of the transaction. This field represents the monetary value of the transaction.'
+  })
+  amount: number
+
+  @Field(() => Date, {
+    description:
+      'The date of the transaction. This field records the exact date when the transaction occurred.'
+  })
+  date: Date
+
+  @Field(() => TransactionType, {
+    description:
+      'The type of the transaction. This field categorizes the transaction as either an income or an expense.'
+  })
+  type: keyof typeof TransactionType
+
+  @Field(() => GraphQLCuid, {
+    description:
+      'The unique identifier (ID) of the wallet associated with the transaction. This is a unique string assigned to each wallet upon creation and is used for wallet identification within the application.'
+  })
+  walletId: string
+
+  @Field(() => Date, {
+    description:
+      'The creation timestamp of the transaction. This field records the exact date and time when the transaction was created.'
+  })
+  createdAt: Date
+
+  @Field(() => Date, {
+    description:
+      "The last update timestamp of the transaction. This field records the most recent date and time when the transaction's information was modified."
+  })
+  updatedAt: Date
+}

--- a/apps/api/src/transactions/fields/transaction-pagination-fields.resolver.ts
+++ b/apps/api/src/transactions/fields/transaction-pagination-fields.resolver.ts
@@ -1,0 +1,40 @@
+import { UseGuards } from '@nestjs/common'
+import { Int, ResolveField, Resolver } from '@nestjs/graphql'
+import { User } from '@prisma/client'
+
+import { GqlAuthGuard } from '@/auth/guards/gql-auth.guard'
+import { CurrentUser } from '@/common/decorators/current-user.decorator'
+import { ParentArgs } from '@/common/decorators/parent-args.decorator'
+import { FindManyTransactionArgs } from '../dto/find-many-transaction.dto'
+import { TransactionPagination } from '../entities/transaction-pagination.entity'
+import { Transaction } from '../entities/transaction.entity'
+import { TransactionsService } from '../transactions.service'
+
+@Resolver(() => TransactionPagination)
+export class TransactionPaginationFieldsResolver {
+  constructor(private readonly transactionsService: TransactionsService) {}
+
+  @UseGuards(GqlAuthGuard)
+  @ResolveField(() => [Transaction], {
+    description:
+      'Retrieve a list of transactions within the application. This field returns an array of transactions based on the provided query arguments.'
+  })
+  nodes(
+    @ParentArgs(FindManyTransactionArgs) args: FindManyTransactionArgs,
+    @CurrentUser() currentUser: User
+  ): Promise<Transaction[]> {
+    return this.transactionsService.findMany(currentUser.id, args)
+  }
+
+  @UseGuards(GqlAuthGuard)
+  @ResolveField(() => Int, {
+    description:
+      'Retrieve the total count of transactions within the application. This field returns the total number of transactions based on the provided query arguments.'
+  })
+  totalCount(
+    @ParentArgs(FindManyTransactionArgs) args: FindManyTransactionArgs,
+    @CurrentUser() currentUser: User
+  ): Promise<number> {
+    return this.transactionsService.count(currentUser.id, args.where)
+  }
+}

--- a/apps/api/src/transactions/transactions.module.ts
+++ b/apps/api/src/transactions/transactions.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common'
+
+import { TransactionPaginationFieldsResolver } from './fields/transaction-pagination-fields.resolver'
+import { TransactionsResolver } from './transactions.resolver'
+import { TransactionsService } from './transactions.service'
+
+@Module({
+  providers: [
+    TransactionsService,
+    TransactionsResolver,
+    TransactionPaginationFieldsResolver
+  ]
+})
+export class TransactionsModule {}

--- a/apps/api/src/transactions/transactions.resolver.ts
+++ b/apps/api/src/transactions/transactions.resolver.ts
@@ -1,0 +1,75 @@
+import { UseGuards } from '@nestjs/common'
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql'
+import { User } from '@prisma/client'
+
+import { GqlAuthGuard } from '@/auth/guards/gql-auth.guard'
+import { CurrentUser } from '@/common/decorators/current-user.decorator'
+import { CreateTransactionArgs } from './dto/create-transaction.dto'
+import { DeleteTransactionArgs } from './dto/delete-transaction.dto'
+import { FindManyTransactionArgs } from './dto/find-many-transaction.dto'
+import { FindUniqueTransactionArgs } from './dto/find-unique-transaction.dto'
+import { UpdateTransactionArgs } from './dto/update-transaction.dto'
+import { TransactionPagination } from './entities/transaction-pagination.entity'
+import { Transaction } from './entities/transaction.entity'
+import { TransactionsService } from './transactions.service'
+
+@Resolver()
+export class TransactionsResolver {
+  constructor(private readonly transactionsService: TransactionsService) {}
+
+  @UseGuards(GqlAuthGuard)
+  @Mutation(() => Transaction, {
+    description: 'Create a new transaction within the application.'
+  })
+  async createTransaction(
+    @Args() args: CreateTransactionArgs,
+    @CurrentUser() currentUser: User
+  ): Promise<Transaction> {
+    return this.transactionsService.create(args.input, currentUser.id)
+  }
+
+  @UseGuards(GqlAuthGuard)
+  @Mutation(() => Transaction, {
+    description: 'Update an existing transaction within the application.'
+  })
+  async updateTransaction(
+    @Args() args: UpdateTransactionArgs,
+    @CurrentUser() currentUser: User
+  ): Promise<Transaction> {
+    return this.transactionsService.update(args.id, currentUser.id, args.input)
+  }
+
+  @UseGuards(GqlAuthGuard)
+  @Mutation(() => Transaction, {
+    description: 'Delete an existing transaction within the application.'
+  })
+  async deleteTransaction(
+    @Args() args: DeleteTransactionArgs,
+    @CurrentUser() currentUser: User
+  ): Promise<Transaction> {
+    return this.transactionsService.delete(args.id, currentUser.id)
+  }
+
+  @UseGuards(GqlAuthGuard)
+  @Query(() => Transaction, {
+    nullable: true,
+    name: 'transaction',
+    description: 'Retrieve a single transaction within the application.'
+  })
+  async findUniqueTransaction(
+    @Args() args: FindUniqueTransactionArgs,
+    @CurrentUser() currentUser: User
+  ): Promise<Transaction | null> {
+    return this.transactionsService.findUnique({ id: args.id }, currentUser.id)
+  }
+
+  @UseGuards(GqlAuthGuard)
+  @Query(() => TransactionPagination, {
+    nullable: true,
+    name: 'transactions',
+    description: 'Retrieve multiple transactions within the application.'
+  })
+  findManyTransactions(@Args() _args: FindManyTransactionArgs): boolean {
+    return true
+  }
+}

--- a/apps/api/src/transactions/transactions.service.ts
+++ b/apps/api/src/transactions/transactions.service.ts
@@ -1,0 +1,138 @@
+import { Injectable, NotFoundException } from '@nestjs/common'
+import { Prisma, Transaction } from '@prisma/client'
+import { PrismaService } from 'nestjs-prisma'
+
+import { CreateTransactionInput } from './dto/create-transaction.dto'
+import { UpdateTransactionInput } from './dto/update-transaction.dto'
+
+@Injectable()
+export class TransactionsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(
+    input: CreateTransactionInput,
+    currentUserId: string
+  ): Promise<Transaction> {
+    const wallet = await this.prisma.wallet.findUnique({
+      where: { id: input.walletId, userId: currentUserId }
+    })
+
+    if (!wallet) throw new NotFoundException('Wallet not found')
+
+    const [transaction] = await this.prisma.$transaction([
+      this.prisma.transaction.create({
+        data: {
+          title: input.title,
+          amount: input.amount,
+          date: input.date,
+          type: input.type,
+          walletId: input.walletId
+        }
+      }),
+      this.prisma.wallet.update({
+        where: { id: input.walletId },
+        data: {
+          currentBalance:
+            input.type === 'INCOME'
+              ? wallet.currentBalance + input.amount
+              : wallet.currentBalance - input.amount
+        }
+      })
+    ])
+
+    return transaction
+  }
+
+  async update(
+    id: string,
+    currentUserId: string,
+    input: UpdateTransactionInput
+  ): Promise<Transaction> {
+    const transaction = await this.prisma.transaction.findUnique({
+      where: { id, wallet: { userId: currentUserId } },
+      include: { wallet: true }
+    })
+
+    if (!transaction) throw new NotFoundException('Transaction not found')
+
+    const difference =
+      input.amount !== undefined ? input.amount - transaction.amount : 0
+    const newCurrentBalance = transaction.wallet.currentBalance + difference
+
+    const [updatedTransaction] = await this.prisma.$transaction([
+      this.prisma.transaction.update({
+        where: { id },
+        data: input
+      }),
+      this.prisma.wallet.update({
+        where: { id: transaction.walletId },
+        data: {
+          currentBalance: newCurrentBalance
+        }
+      })
+    ])
+
+    return updatedTransaction
+  }
+
+  async delete(id: string, currentUserId: string): Promise<Transaction> {
+    const transaction = await this.prisma.transaction.findUnique({
+      where: { id, wallet: { userId: currentUserId } },
+      include: { wallet: true }
+    })
+
+    if (!transaction) throw new NotFoundException('Transaction not found')
+
+    const [deletedTransaction] = await this.prisma.$transaction([
+      this.prisma.transaction.delete({
+        where: { id }
+      }),
+      this.prisma.wallet.update({
+        where: { id: transaction.walletId },
+        data: {
+          currentBalance:
+            transaction.type === 'INCOME'
+              ? transaction.wallet.currentBalance - transaction.amount
+              : transaction.wallet.currentBalance + transaction.amount
+        }
+      })
+    ])
+
+    return deletedTransaction
+  }
+
+  async findUnique(
+    where: Prisma.TransactionWhereUniqueInput,
+    currentUserId: string
+  ): Promise<Transaction | null> {
+    return this.prisma.transaction.findUnique({
+      where: {
+        ...where,
+        wallet: { userId: currentUserId }
+      }
+    })
+  }
+
+  async findMany(
+    currentUserId: string,
+    args?: Prisma.TransactionFindManyArgs
+  ): Promise<Transaction[]> {
+    return this.prisma.transaction.findMany({
+      ...args,
+      where: {
+        AND: [{ ...args?.where }, { wallet: { userId: currentUserId } }]
+      }
+    })
+  }
+
+  async count(
+    currentUserId: string,
+    where?: Prisma.TransactionWhereInput
+  ): Promise<number> {
+    return this.prisma.transaction.count({
+      where: {
+        AND: [{ ...where }, { wallet: { userId: currentUserId } }]
+      }
+    })
+  }
+}

--- a/apps/api/src/wallets/entities/wallet-pagination.entity.ts
+++ b/apps/api/src/wallets/entities/wallet-pagination.entity.ts
@@ -2,6 +2,6 @@ import { ObjectType } from '@nestjs/graphql'
 
 @ObjectType({
   description:
-    'Tge WalletPagination object represents a paginated list of wallets within the application.'
+    'The WalletPagination object represents a paginated list of wallets within the application.'
 })
 export class WalletPagination {}


### PR DESCRIPTION
J'ai ajouté le module des transactions par rapport à l'issue #7 

On peut donc créer/update/supprimer et lire nos transactions. Cela représente un CRUD classique.
Le petit truc est que lorsque le une transaction est créée ou que le `amount` est modifié ou que une transaction est supprimée, cela met à jour le `currentBalance` du wallet qui est lié.

On peut accéder uniquement aux transactions de nos wallets.